### PR TITLE
fixing .cpu().numpy() for running GM Opt on GPU

### DIFF
--- a/singa_easy/models/TorchModel.py
+++ b/singa_easy/models/TorchModel.py
@@ -248,7 +248,7 @@ class TorchModel(SINGAEasyModel):
             for name, f in self._model.named_parameters():
                 self._gm_optimizer.gm_register(
                     name,
-                    f.data.to(self.device).numpy(),
+                    f.data.to(self.device).cpu().numpy(),
                     model_name="PyVGG",
                     hyperpara_list=[
                         self._knobs.get("gm_prior_regularization_a"),


### PR DESCRIPTION
Error happens when we testing with GPU since the tensor need to be moved to .cpu() before doing .numpy().