### PR TITLE
fix 'deserialize object' for CPU-only machine

### DIFF
--- a/singa_easy/models/TorchModel.py
+++ b/singa_easy/models/TorchModel.py
@@ -632,7 +632,12 @@ class TorchModel(SINGAEasyModel):
                     model=self._model,
                     num_groups=self._knobs.get("model_slicing_groups"),
                     sr_in_list=[0.5, 0.75, 1.0])
-            self._model.load_state_dict(torch.load(tmp.name))
+            if torch.cuda.is_available() == False:
+                print ('GPU is not available. Model parameters storages are mapped to CPU')
+                self._model.load_state_dict(torch.load(tmp.name,map_location=torch.device('cpu')))
+            else:
+                print ('GPU is available. Model parameters storages are mapped to GPU')
+                self._model.load_state_dict(torch.load(tmp.name))
 
         if self._knobs.get("enable_label_adaptation"):
             self._label_drift_adapter = LabelDriftAdapter(


### PR DESCRIPTION
fix "RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location='cpu' to map your storages to the CPU."